### PR TITLE
Package skeleton for ZANA Axial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # ZANAGENT
+
+This repository packages the ZANA Axial CLI agent as an installable Python package.
+
+## Installation
+
+```bash
+pip install .
+```
+
+## Usage
+
+After installation, run the CLI:
+
+```bash
+zana --help
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zana-axial"
+version = "0.1.0"
+description = "ZANA Axial — monolithic CLI agent"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+
+[project.optional-dependencies]
+full = ["numpy", "pandas", "matplotlib"]
+
+[project.scripts]
+zana = "zana_axial.cli:main"

--- a/zana_axial/__init__.py
+++ b/zana_axial/__init__.py
@@ -1,0 +1,4 @@
+"""ZANA Axial package."""
+from .cli import main
+
+__all__ = ["main"]

--- a/zana_axial/cli.py
+++ b/zana_axial/cli.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+ZANA Axial — Monolithic, deterministically exact CLI agent.
+
+This package provides a CLI entry point but the full agent implementation
+from the original script is not included here.
+"""
+
+def main() -> None:
+    """CLI entry point."""
+    print("ZANA Axial CLI is not yet fully implemented.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up `zana-axial` as an installable package
- add placeholder CLI entry point and script metadata
- document installation and usage in README

## Testing
- `python -m pip install -e .`
- `python -m zana_axial.cli --help`
- `~/.pyenv/versions/3.12.10/bin/zana --help`


------
https://chatgpt.com/codex/tasks/task_e_68ab05212e4c832e85724779199533ec